### PR TITLE
feat(MumbleLogo): add logo

### DIFF
--- a/packages/app/pages/includes/navi.tsx
+++ b/packages/app/pages/includes/navi.tsx
@@ -5,7 +5,6 @@ import {
   MumbleLogo,
   NaviButton,
   Navigation,
-  NavigationContainer,
   NavigationColumn,
   NavigationRow,
 } from '@smartive-education/design-system-component-library-yeahyeahyeah';
@@ -27,48 +26,42 @@ export default function Navi() {
         <Link href="./textbox">Textbox</Link>
         <Link href="./hashtag">Hashtag</Link>
       </div>
-      <Navigation mbSpacing="32">
-        <NavigationContainer>
-          <NavigationColumn>
-            <Link href="/" title="Startpage" target="_self">
-              <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
-            </Link>
-            <NavigationRow>
-              <NaviButton
-                label="Profile"
-                variant="profile"
-                href="/profilepage"
-                legacyBehavior={true}
-                passHref={true}
-                linkComponent={Link}
-              >
-                <Avatar
-                  alt="Small Avatar"
-                  src="https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif"
-                  variant="small"
-                />
-              </NaviButton>
-              <NaviButton
-                label="Settings"
-                variant="default"
-                icon="settings"
-                href="/"
-                legacyBehavior={true}
-                passHref={true}
-                linkComponent={Link}
-              />
-              <NaviButton
-                label="Logout"
-                variant="default"
-                icon="logout"
-                href="/detailview"
-                legacyBehavior={true}
-                passHref={true}
-                linkComponent={Link}
-              />
-            </NavigationRow>
-          </NavigationColumn>
-        </NavigationContainer>
+      <Navigation>
+        <NavigationColumn>
+          <Link href="/detailview" title="Startpage" target="_self">
+            <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
+          </Link>
+          <NavigationRow>
+            <NaviButton
+              label="Profile"
+              variant="profile"
+              href="/profilepage"
+              legacyBehavior={true}
+              passHref={true}
+              linkComponent={Link}
+            >
+              <Avatar alt="Small Avatar" src="https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif" variant="small" />
+            </NaviButton>
+            <NaviButton
+              label="Settings"
+              variant="default"
+              icon="settings"
+              href="/"
+              legacyBehavior={true}
+              passHref={true}
+              linkComponent={Link}
+            />
+            <NaviButton
+              label="Logout"
+              variant="default"
+              icon="logout"
+              href="/detailview"
+              legacyBehavior={true}
+              passHref={true}
+              linkComponent={Link}
+            />
+          </NavigationRow>
+        </NavigationColumn>
       </Navigation>
     </>
   );

--- a/packages/app/pages/includes/navi.tsx
+++ b/packages/app/pages/includes/navi.tsx
@@ -27,51 +27,49 @@ export default function Navi() {
         <Link href="./textbox">Textbox</Link>
         <Link href="./hashtag">Hashtag</Link>
       </div>
-      <div tw="w-full mb-32">
-        <Navigation>
-          <NavigationContainer>
-            <NavigationColumn>
-              <Link href="/" title="Startpage" target="_self">
-                <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
-              </Link>
-              <NavigationRow>
-                <NaviButton
-                  label="Profile"
-                  variant="profile"
-                  href="/profilepage"
-                  legacyBehavior={true}
-                  passHref={true}
-                  linkComponent={Link}
-                >
-                  <Avatar
-                    alt="Small Avatar"
-                    src="https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif"
-                    variant="small"
-                  />
-                </NaviButton>
-                <NaviButton
-                  label="Settings"
-                  variant="default"
-                  icon="settings"
-                  href="/"
-                  legacyBehavior={true}
-                  passHref={true}
-                  linkComponent={Link}
+      <Navigation mbSpacing="32">
+        <NavigationContainer>
+          <NavigationColumn>
+            <Link href="/" title="Startpage" target="_self">
+              <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
+            </Link>
+            <NavigationRow>
+              <NaviButton
+                label="Profile"
+                variant="profile"
+                href="/profilepage"
+                legacyBehavior={true}
+                passHref={true}
+                linkComponent={Link}
+              >
+                <Avatar
+                  alt="Small Avatar"
+                  src="https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif"
+                  variant="small"
                 />
-                <NaviButton
-                  label="Logout"
-                  variant="default"
-                  icon="logout"
-                  href="/detailview"
-                  legacyBehavior={true}
-                  passHref={true}
-                  linkComponent={Link}
-                />
-              </NavigationRow>
-            </NavigationColumn>
-          </NavigationContainer>
-        </Navigation>
-      </div>
+              </NaviButton>
+              <NaviButton
+                label="Settings"
+                variant="default"
+                icon="settings"
+                href="/"
+                legacyBehavior={true}
+                passHref={true}
+                linkComponent={Link}
+              />
+              <NaviButton
+                label="Logout"
+                variant="default"
+                icon="logout"
+                href="/detailview"
+                legacyBehavior={true}
+                passHref={true}
+                linkComponent={Link}
+              />
+            </NavigationRow>
+          </NavigationColumn>
+        </NavigationContainer>
+      </Navigation>
     </>
   );
 }

--- a/packages/app/pages/includes/navi.tsx
+++ b/packages/app/pages/includes/navi.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import Link from 'next/link';
-import { Avatar, NaviButton, Navigation } from '@smartive-education/design-system-component-library-yeahyeahyeah';
+import {
+  Avatar,
+  MumbleLogo,
+  NaviButton,
+  Navigation,
+  NavigationContainer,
+  NavigationColumn,
+  NavigationRow,
+} from '@smartive-education/design-system-component-library-yeahyeahyeah';
 import { useRouter } from 'next/router';
 
 export default function Navi() {
@@ -21,34 +29,47 @@ export default function Navi() {
       </div>
       <div tw="w-full mb-32">
         <Navigation title="Mumble Logo">
-          <NaviButton
-            label="Profile"
-            variant="profile"
-            href="/profilepage"
-            legacyBehavior={true}
-            passHref={true}
-            linkComponent={Link}
-          >
-            <Avatar alt="Small Avatar" src="https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif" variant="small" />
-          </NaviButton>
-          <NaviButton
-            label="Settings"
-            variant="default"
-            icon="settings"
-            href="/"
-            legacyBehavior={true}
-            passHref={true}
-            linkComponent={Link}
-          />
-          <NaviButton
-            label="Logout"
-            variant="default"
-            icon="logout"
-            href="/detailview"
-            legacyBehavior={true}
-            passHref={true}
-            linkComponent={Link}
-          />
+          <NavigationContainer>
+            <NavigationColumn>
+              <Link href="/" title="Startpage" target="_self">
+                <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
+              </Link>
+              <NavigationRow>
+                <NaviButton
+                  label="Profile"
+                  variant="profile"
+                  href="/profilepage"
+                  legacyBehavior={true}
+                  passHref={true}
+                  linkComponent={Link}
+                >
+                  <Avatar
+                    alt="Small Avatar"
+                    src="https://media.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif"
+                    variant="small"
+                  />
+                </NaviButton>
+                <NaviButton
+                  label="Settings"
+                  variant="default"
+                  icon="settings"
+                  href="/"
+                  legacyBehavior={true}
+                  passHref={true}
+                  linkComponent={Link}
+                />
+                <NaviButton
+                  label="Logout"
+                  variant="default"
+                  icon="logout"
+                  href="/detailview"
+                  legacyBehavior={true}
+                  passHref={true}
+                  linkComponent={Link}
+                />
+              </NavigationRow>
+            </NavigationColumn>
+          </NavigationContainer>
         </Navigation>
       </div>
     </>

--- a/packages/app/pages/includes/navi.tsx
+++ b/packages/app/pages/includes/navi.tsx
@@ -28,7 +28,7 @@ export default function Navi() {
         <Link href="./hashtag">Hashtag</Link>
       </div>
       <div tw="w-full mb-32">
-        <Navigation title="Mumble Logo">
+        <Navigation>
           <NavigationContainer>
             <NavigationColumn>
               <Link href="/" title="Startpage" target="_self">

--- a/packages/design-system-component-library-yeahyeahyeah/components/image/MumbleLogo.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/image/MumbleLogo.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import tw, { styled, TwStyle } from 'twin.macro';
+import { MumbleText, MumbleGradient, LogoMumble as Logo } from '../icon/index';
+
+export interface MumbleLogoProps {
+  color: 'violet' | 'gradient' | 'white';
+  alignment: 'horizontal' | 'vertical';
+  isNavigation?: boolean;
+  onLogoClick?: () => void;
+}
+
+export const MumbleLogo: React.FC<MumbleLogoProps> = ({
+  color = 'white',
+  alignment = 'horizontal',
+  isNavigation = true,
+  onLogoClick,
+}) => {
+  const [hover, setHover] = useState(false);
+
+  return (
+    <MumbleLogoStyledDiv
+      alignment={alignment}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={onLogoClick}
+    >
+      <StyledLogoMumble color={color} hover={hover ? 'true' : 'false'} navigation={isNavigation ? 'true' : 'false'} />
+
+      {color !== 'gradient' ? (
+        <StyledMumbleText
+          color={color}
+          navigation={isNavigation ? 'true' : 'false'}
+          alignment={alignment}
+          hover={hover ? 'true' : 'false'}
+        />
+      ) : (
+        <StyledMumbleGradient
+          navigation={isNavigation ? 'true' : 'false'}
+          alignment={alignment}
+          hover={hover ? 'true' : 'false'}
+        />
+      )}
+    </MumbleLogoStyledDiv>
+  );
+};
+
+type IStyled = {
+  hover: 'true' | 'false';
+  color: 'violet' | 'gradient' | 'white';
+  alignment: 'horizontal' | 'vertical';
+  navigation: 'true' | 'false';
+};
+
+type IMumbleLogoStyledDiv = Pick<IStyled, 'alignment'>;
+
+const MumbleLogoStyledDiv = styled.div(({ alignment }: IMumbleLogoStyledDiv) => [
+  tw`
+    flex
+    justify-between
+    items-center
+    p-0
+    cursor-pointer
+    w-[130px]
+    sm:w-auto
+  `,
+  alignment === 'vertical' && tw`flex-col`,
+  alignment === 'horizontal' && tw`flex-row`,
+]);
+
+type IStyledLogoMumble = Pick<IStyled, 'color' | 'hover' | 'navigation'>;
+
+const StyledLogoMumble = styled(Logo)(({ color, hover, navigation }: IStyledLogoMumble) => [
+  tw`fill-violet-600`,
+  navigation === 'true' ? tw`w-48 h-48` : tw`w-64 h-64 `,
+  IconColor(color, hover),
+]);
+
+type IStyledMumbleText = Pick<IStyled, 'alignment' | 'navigation' | 'color' | 'hover'>;
+
+const StyledMumbleText = styled(MumbleText)(({ alignment, navigation, color, hover }: IStyledMumbleText) => [
+  navigation === 'true' ? tw`h-[30px] w-[154px]` : tw`h-[48px] w-[246px]`,
+  TextSvgStyles(alignment, navigation),
+  IconColor(color, hover),
+]);
+
+type IStyledMumbleGradient = Pick<IStyled, 'alignment' | 'navigation' | 'hover'>;
+
+const StyledMumbleGradient = styled(MumbleGradient)(({ alignment, navigation }: IStyledMumbleGradient) => [
+  navigation === 'true' ? tw`h-[30px] w-[154px]` : tw`h-[48px] w-[246px]`,
+  TextSvgStyles(alignment, navigation),
+]);
+
+const IconColor = (color: string, hover: string) => {
+  let hoverColor: TwStyle;
+  let defaultColor: TwStyle;
+
+  switch (color) {
+    case 'violet':
+      defaultColor = tw`fill-violet-600`;
+      hoverColor = tw`fill-slate-white`;
+      return hover === 'true' ? hoverColor : defaultColor;
+    case 'gradient':
+      defaultColor = tw`fill-violet-600`;
+      hoverColor = tw`fill-slate-white`;
+      return hover === 'true' ? hoverColor : defaultColor;
+    case 'white':
+      defaultColor = tw`fill-slate-white`;
+      hoverColor = tw`fill-slate-300`;
+      return hover === 'true' ? hoverColor : defaultColor;
+  }
+  return null;
+};
+
+const TextSvgStyles = (alignment: string, navigation: string) => {
+  switch (alignment) {
+    case 'horizontal':
+      return navigation === 'true' ? (tw`ml-8 sm:ml-16` as TwStyle) : (tw`ml-8 sm:ml-16 ` as TwStyle);
+    case 'vertical':
+      return navigation === 'true' ? (tw`mt-8` as TwStyle) : (tw`mt-16` as TwStyle);
+  }
+  return null;
+};

--- a/packages/design-system-component-library-yeahyeahyeah/components/image/MumbleLogo.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/image/MumbleLogo.tsx
@@ -3,7 +3,6 @@ import tw, { styled, TwStyle } from 'twin.macro';
 import { MumbleText, MumbleGradient, LogoMumble as Logo } from '../icon/index';
 
 export interface IMumbleLogoProps {
-  title: string;
   color: 'violet' | 'gradient' | 'white';
   alignment: 'horizontal' | 'vertical';
   onLogoClick?: () => void;
@@ -19,17 +18,20 @@ export const MumbleLogo: React.FC<IMumbleLogoProps> = ({
   const [hover, setHover] = useState(false);
 
   return (
-    <MumbleLogoStyledLink onClick={onLogoClick} onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
-      <MumbleLogoStyledDiv alignment={alignment}>
-        <StyledLogoMumble color={color} $hover={hover} $navigation={isNavigation} />
+    <MumbleLogoStyledDiv
+      alignment={alignment}
+      onClick={onLogoClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <StyledLogoMumble color={color} $hover={hover} $navigation={isNavigation} />
 
-        {color !== 'gradient' ? (
-          <StyledMumbleText color={color} $navigation={isNavigation} alignment={alignment} $hover={hover} />
-        ) : (
-          <StyledMumbleGradient $navigation={isNavigation} alignment={alignment} $hover={hover} />
-        )}
-      </MumbleLogoStyledDiv>
-    </MumbleLogoStyledLink>
+      {color !== 'gradient' ? (
+        <StyledMumbleText color={color} $navigation={isNavigation} alignment={alignment} $hover={hover} />
+      ) : (
+        <StyledMumbleGradient $navigation={isNavigation} alignment={alignment} $hover={hover} />
+      )}
+    </MumbleLogoStyledDiv>
   );
 };
 
@@ -54,12 +56,6 @@ const MumbleLogoStyledDiv = styled.div(({ alignment }: IMumbleLogoStyledDiv) => 
   `,
   alignment === 'vertical' && tw`flex-col`,
   alignment === 'horizontal' && tw`flex-row`,
-]);
-
-const MumbleLogoStyledLink = styled.a(() => [
-  tw`
-    cursor-pointer
-  `,
 ]);
 
 type IStyledLogoMumble = Pick<IStyled, 'color' | '$hover' | '$navigation'>;

--- a/packages/design-system-component-library-yeahyeahyeah/components/image/MumbleLogo.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/image/MumbleLogo.tsx
@@ -2,53 +2,42 @@ import React, { useState } from 'react';
 import tw, { styled, TwStyle } from 'twin.macro';
 import { MumbleText, MumbleGradient, LogoMumble as Logo } from '../icon/index';
 
-export interface MumbleLogoProps {
+export interface IMumbleLogoProps {
+  title: string;
   color: 'violet' | 'gradient' | 'white';
   alignment: 'horizontal' | 'vertical';
-  isNavigation?: boolean;
   onLogoClick?: () => void;
+  isNavigation?: boolean;
 }
 
-export const MumbleLogo: React.FC<MumbleLogoProps> = ({
+export const MumbleLogo: React.FC<IMumbleLogoProps> = ({
   color = 'white',
   alignment = 'horizontal',
-  isNavigation = true,
   onLogoClick,
+  isNavigation = true,
 }) => {
   const [hover, setHover] = useState(false);
 
   return (
-    <MumbleLogoStyledDiv
-      alignment={alignment}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onClick={onLogoClick}
-    >
-      <StyledLogoMumble color={color} hover={hover ? 'true' : 'false'} navigation={isNavigation ? 'true' : 'false'} />
+    <MumbleLogoStyledLink onClick={onLogoClick} onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
+      <MumbleLogoStyledDiv alignment={alignment}>
+        <StyledLogoMumble color={color} $hover={hover} $navigation={isNavigation} />
 
-      {color !== 'gradient' ? (
-        <StyledMumbleText
-          color={color}
-          navigation={isNavigation ? 'true' : 'false'}
-          alignment={alignment}
-          hover={hover ? 'true' : 'false'}
-        />
-      ) : (
-        <StyledMumbleGradient
-          navigation={isNavigation ? 'true' : 'false'}
-          alignment={alignment}
-          hover={hover ? 'true' : 'false'}
-        />
-      )}
-    </MumbleLogoStyledDiv>
+        {color !== 'gradient' ? (
+          <StyledMumbleText color={color} $navigation={isNavigation} alignment={alignment} $hover={hover} />
+        ) : (
+          <StyledMumbleGradient $navigation={isNavigation} alignment={alignment} $hover={hover} />
+        )}
+      </MumbleLogoStyledDiv>
+    </MumbleLogoStyledLink>
   );
 };
 
 type IStyled = {
-  hover: 'true' | 'false';
+  $hover: boolean;
+  $navigation: boolean;
   color: 'violet' | 'gradient' | 'white';
   alignment: 'horizontal' | 'vertical';
-  navigation: 'true' | 'false';
 };
 
 type IMumbleLogoStyledDiv = Pick<IStyled, 'alignment'>;
@@ -67,30 +56,36 @@ const MumbleLogoStyledDiv = styled.div(({ alignment }: IMumbleLogoStyledDiv) => 
   alignment === 'horizontal' && tw`flex-row`,
 ]);
 
-type IStyledLogoMumble = Pick<IStyled, 'color' | 'hover' | 'navigation'>;
+const MumbleLogoStyledLink = styled.a(() => [
+  tw`
+    cursor-pointer
+  `,
+]);
 
-const StyledLogoMumble = styled(Logo)(({ color, hover, navigation }: IStyledLogoMumble) => [
+type IStyledLogoMumble = Pick<IStyled, 'color' | '$hover' | '$navigation'>;
+
+const StyledLogoMumble = styled(Logo)(({ color, $hover, $navigation }: IStyledLogoMumble) => [
   tw`fill-violet-600`,
-  navigation === 'true' ? tw`w-48 h-48` : tw`w-64 h-64 `,
-  IconColor(color, hover),
+  $navigation === true ? tw`w-48 h-48` : tw`w-64 h-64 `,
+  IconColor(color, $hover),
 ]);
 
-type IStyledMumbleText = Pick<IStyled, 'alignment' | 'navigation' | 'color' | 'hover'>;
+type IStyledMumbleText = Pick<IStyled, 'alignment' | '$navigation' | 'color' | '$hover'>;
 
-const StyledMumbleText = styled(MumbleText)(({ alignment, navigation, color, hover }: IStyledMumbleText) => [
-  navigation === 'true' ? tw`h-[30px] w-[154px]` : tw`h-[48px] w-[246px]`,
-  TextSvgStyles(alignment, navigation),
-  IconColor(color, hover),
+const StyledMumbleText = styled(MumbleText)(({ alignment, $navigation, color, $hover }: IStyledMumbleText) => [
+  $navigation === true ? tw`h-[30px] w-[154px]` : tw`h-[48px] w-[246px]`,
+  TextSvgStyles(alignment, $navigation),
+  IconColor(color, $hover),
 ]);
 
-type IStyledMumbleGradient = Pick<IStyled, 'alignment' | 'navigation' | 'hover'>;
+type IStyledMumbleGradient = Pick<IStyled, 'alignment' | '$navigation' | '$hover'>;
 
-const StyledMumbleGradient = styled(MumbleGradient)(({ alignment, navigation }: IStyledMumbleGradient) => [
-  navigation === 'true' ? tw`h-[30px] w-[154px]` : tw`h-[48px] w-[246px]`,
-  TextSvgStyles(alignment, navigation),
+const StyledMumbleGradient = styled(MumbleGradient)(({ alignment, $navigation }: IStyledMumbleGradient) => [
+  $navigation === true ? tw`h-[30px] w-[154px]` : tw`h-[48px] w-[246px]`,
+  TextSvgStyles(alignment, $navigation),
 ]);
 
-const IconColor = (color: string, hover: string) => {
+const IconColor = (color: string, $hover: boolean) => {
   let hoverColor: TwStyle;
   let defaultColor: TwStyle;
 
@@ -98,25 +93,25 @@ const IconColor = (color: string, hover: string) => {
     case 'violet':
       defaultColor = tw`fill-violet-600`;
       hoverColor = tw`fill-slate-white`;
-      return hover === 'true' ? hoverColor : defaultColor;
+      return $hover === true ? hoverColor : defaultColor;
     case 'gradient':
       defaultColor = tw`fill-violet-600`;
       hoverColor = tw`fill-slate-white`;
-      return hover === 'true' ? hoverColor : defaultColor;
+      return $hover === true ? hoverColor : defaultColor;
     case 'white':
       defaultColor = tw`fill-slate-white`;
       hoverColor = tw`fill-slate-300`;
-      return hover === 'true' ? hoverColor : defaultColor;
+      return $hover === true ? hoverColor : defaultColor;
   }
   return null;
 };
 
-const TextSvgStyles = (alignment: string, navigation: string) => {
+const TextSvgStyles = (alignment: string, $navigation: boolean) => {
   switch (alignment) {
     case 'horizontal':
-      return navigation === 'true' ? (tw`ml-8 sm:ml-16` as TwStyle) : (tw`ml-8 sm:ml-16 ` as TwStyle);
+      return $navigation === true ? (tw`ml-8 sm:ml-16` as TwStyle) : (tw`ml-8 sm:ml-16 ` as TwStyle);
     case 'vertical':
-      return navigation === 'true' ? (tw`mt-8` as TwStyle) : (tw`mt-16` as TwStyle);
+      return $navigation === true ? (tw`mt-8` as TwStyle) : (tw`mt-16` as TwStyle);
   }
   return null;
 };

--- a/packages/design-system-component-library-yeahyeahyeah/components/image/index.ts
+++ b/packages/design-system-component-library-yeahyeahyeah/components/image/index.ts
@@ -1,2 +1,3 @@
 export * from './Image';
 export * from './ImageContainer';
+export * from './MumbleLogo';

--- a/packages/design-system-component-library-yeahyeahyeah/components/navigation/Navigation.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/navigation/Navigation.tsx
@@ -4,7 +4,6 @@ import tw from 'twin.macro';
 import { NavigationContainer } from './NavigationStyles';
 
 export type NavigationProps = {
-  title: 'Mumble Logo';
   children?: React.ReactNode;
 };
 

--- a/packages/design-system-component-library-yeahyeahyeah/components/navigation/Navigation.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/navigation/Navigation.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
 import tw from 'twin.macro';
+import type { TmbSpacing } from '../../types/types';
+import { BottomSpacing } from '../../styles/Spacing';
 import { NavigationContainer } from './NavigationStyles';
 
 export type NavigationProps = {
   children?: React.ReactNode;
+  mbSpacing?: TmbSpacing;
 };
 
-export const Navigation = ({ children }: NavigationProps) => {
+export const Navigation = ({ children, mbSpacing }: NavigationProps) => {
   return (
-    <HeaderStyles>
+    <HeaderStyles mbSpacing={mbSpacing}>
       <NavigationStyles>
         <NavigationContainer>{children}</NavigationContainer>
       </NavigationStyles>
@@ -17,9 +20,12 @@ export const Navigation = ({ children }: NavigationProps) => {
   );
 };
 
-const HeaderStyles = tw.header`
-  w-full
-`;
+const HeaderStyles = styled.header(() => [
+  tw`
+    w-full    
+	`,
+  BottomSpacing,
+]);
 
 const NavigationStyles = styled.nav(() => [
   tw`

--- a/packages/design-system-component-library-yeahyeahyeah/components/navigation/NavigationStyles.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/navigation/NavigationStyles.tsx
@@ -7,7 +7,9 @@ export const NavigationContainer = tw.div`
   justify-center
   items-center
   container
-  px-16
+  px-0
+  pl-8
+  sm:(px-16 pl-0)
 `;
 
 export const NavigationColumn = tw.div`

--- a/packages/design-system-component-library-yeahyeahyeah/docs/MumbleLogo.md
+++ b/packages/design-system-component-library-yeahyeahyeah/docs/MumbleLogo.md
@@ -1,0 +1,42 @@
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/smartive-education/design-system-component-library-yeahyeahyeah)
+# MumbleLogo
+## MumbleLogo properties
+| Property|Description|
+|-|-|
+|alignment|Choose *horizontal* for integration in *navbar*. Futher details see [Navigation](./?path=/docs/navigation-navigation--navigation-story)|
+|color|*White* is the preferred color for *navbar* integration.|
+|isNavigation|A optimized size for MumbleNavigation.|
+|onLogoClick|JS-Callback function.|
+
+## Include MumbleLogo from the component library in your App
+
+```js
+// index.tsx, index.js, index.jsx
+
+import { MumbleLogo } from "@smartive-education/design-system-component-library-yeahyeahyeah"
+
+```
+
+### MumbleLogo *navigation* snippet
+```js
+
+<MumbleLogo
+  alignment="horizontal"
+  color="white"
+  isNavigation
+  onLogoClick={() => {}}
+/>
+
+```
+
+### MumbleLogo *vertical*, *gradient* example. Can be integrated on *landingpages*
+```js
+
+<MumbleLogo
+  alignment="horizontal"
+  color="white"
+  isNavigation
+  onLogoClick={() => {}}
+/>
+
+```

--- a/packages/design-system-component-library-yeahyeahyeah/stories/image/MumbleLogo.stories.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/stories/image/MumbleLogo.stories.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { MumbleLogo } from '../../components/image/MumbleLogo';
-import React from 'react';
+import MumbleLogoReadme from '../../docs/MumbleLogo.md';
 
 export default {
   title: 'Medias/Logo',
@@ -35,6 +36,9 @@ export const LogoVariants = Template;
 LogoVariants.parameters = {
   docs: {
     source: { type: 'dynamic' },
+    description: {
+      component: MumbleLogoReadme,
+    },
   },
 };
 

--- a/packages/design-system-component-library-yeahyeahyeah/stories/image/MumbleLogo.stories.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/stories/image/MumbleLogo.stories.tsx
@@ -1,0 +1,41 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { MumbleLogo } from '../../components/image/MumbleLogo';
+import React from 'react';
+
+export default {
+  title: 'Medias/Logo',
+  component: MumbleLogo,
+  argTypes: {
+    alignment: {
+      control: 'select',
+    },
+    color: {
+      control: 'select',
+    },
+    isNavigation: {
+      control: 'boolean',
+    },
+    onLogoClick: {
+      action: () => 'handleClick',
+    },
+  },
+  args: {
+    alignment: 'vertical',
+    color: 'violet',
+    isNavigation: false,
+  },
+} as ComponentMeta<typeof MumbleLogo>;
+
+const Template: ComponentStory<typeof MumbleLogo> = (args) => {
+  return <MumbleLogo {...args} />;
+};
+
+export const LogoVariants = Template;
+
+LogoVariants.parameters = {
+  docs: {
+    source: { type: 'dynamic' },
+  },
+};
+
+LogoVariants.storyName = 'Logo';

--- a/packages/design-system-component-library-yeahyeahyeah/stories/navigation/Navigation.stories.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/stories/navigation/Navigation.stories.tsx
@@ -1,7 +1,16 @@
 import React, { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import NavigationReadme from '../../docs/Navigation.md';
-import { Avatar, NaviButton, Navigation, Modal, NavigationContainer, NavigationColumn, NavigationRow } from '../../index';
+import {
+  Avatar,
+  NaviButton,
+  Navigation,
+  Modal,
+  MumbleLogo,
+  NavigationContainer,
+  NavigationColumn,
+  NavigationRow,
+} from '../../index';
 import Link from 'next/link';
 
 export default {
@@ -22,7 +31,9 @@ const Template: ComponentStory<typeof Navigation> = (args) => {
     <Navigation {...args} title="Mumble Logo">
       <NavigationContainer>
         <NavigationColumn>
-          <div tw="text-slate-white">Logo</div>
+          <Link href="#" title="Startpage">
+            <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
+          </Link>
           <NavigationRow>
             <NaviButton
               label="Profile"

--- a/packages/design-system-component-library-yeahyeahyeah/stories/navigation/Navigation.stories.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/stories/navigation/Navigation.stories.tsx
@@ -17,7 +17,6 @@ export default {
   title: 'Navigation/Navigation',
   component: Navigation,
   parameters: { actions: { argTypesRegex: '^on.*' } },
-  argTypes: {},
 } as ComponentMeta<typeof Navigation>;
 
 const Template: ComponentStory<typeof Navigation> = (args) => {
@@ -28,7 +27,7 @@ const Template: ComponentStory<typeof Navigation> = (args) => {
   };
 
   return !open ? (
-    <Navigation {...args} title="Mumble Logo">
+    <Navigation {...args}>
       <NavigationContainer>
         <NavigationColumn>
           <Link href="#" title="Startpage" target="_self">

--- a/packages/design-system-component-library-yeahyeahyeah/stories/navigation/Navigation.stories.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/stories/navigation/Navigation.stories.tsx
@@ -31,7 +31,7 @@ const Template: ComponentStory<typeof Navigation> = (args) => {
     <Navigation {...args} title="Mumble Logo">
       <NavigationContainer>
         <NavigationColumn>
-          <Link href="#" title="Startpage">
+          <Link href="#" title="Startpage" target="_self">
             <MumbleLogo isNavigation={true} color="white" alignment="horizontal" />
           </Link>
           <NavigationRow>


### PR DESCRIPTION
- MumbleLogo wieder integriert
- MumbleLogo im Folder "image" integriert.
- MumbleLogo repräsentiert nun nur noch das Logo selbst, ohne Link-Komponente. Das Logo dient, wie z.B. auf der "Landingpage" nur als Branding-Image das ausser Darstellung keine weitere Funktion hat.
- Navigation-Story: Die Link-Komponente dient als "Wrapper" für das Logo.

Anmerkung: Transient-Boolean Bug lokal bei mir nun nicht aufgepoppt, obwohl "fix" nicht implementiert wurde. Das Konzept "styles" in die Komponente zu inkludieren gefällt mir nicht (siehe navi). TBD!

Test: Navi ist in der App aktualisiert und getestet.