### PR TITLE
fix(avatar): rounded avatar in ios bug

### DIFF
--- a/packages/design-system-component-library-yeahyeahyeah/components/user/Avatar.tsx
+++ b/packages/design-system-component-library-yeahyeahyeah/components/user/Avatar.tsx
@@ -58,6 +58,7 @@ const Styles = ({ variant }: IImageProps) => [
 		cursor-pointer
     object-cover
     overflow-hidden
+    z-10
 	`,
 ];
 
@@ -65,5 +66,6 @@ const StyledImage = styled.img(() => [
   ImageScale({ opacityLevel: '80' }),
   tw`
     w-full
+    overflow-hidden
   `,
 ]);


### PR DESCRIPTION
- Added z-index in "figure"
- Overflow hidden for image in avatar